### PR TITLE
Fix jcrPath not used

### DIFF
--- a/aem-packager.js
+++ b/aem-packager.js
@@ -81,7 +81,7 @@ const getDefines = function (configs) {
   const pathOptions = {
     srcDir: resolvePath(configs.options.srcDir),
     buildDir: resolvePath(configs.options.buildDir),
-    jcrPath: resolvePath(configs.options.jcrPath),
+    jcrPath: resolvePath(configs.options.jcrPath)
   }
 
   _.defaults(

--- a/aem-packager.js
+++ b/aem-packager.js
@@ -80,7 +80,8 @@ const getDefines = function (configs) {
   // Apply configurations from paths
   const pathOptions = {
     srcDir: resolvePath(configs.options.srcDir),
-    buildDir: resolvePath(configs.options.buildDir)
+    buildDir: resolvePath(configs.options.buildDir),
+    jcrPath: resolvePath(configs.options.jcrPath),
   }
 
   _.defaults(


### PR DESCRIPTION
Fixes #40 

## Proposed Changes
- obtain `pathOptions.jcrPath` through `resolvePath` like `srcDir` and `buildDir`

## Background context
`jcrPath` option is not working currently, it always writes output to the default path.

### How should this be manually tested?

1. Define a custom `jcrPath`
2. Run packaging script
2. Check verbose build output for used output directory
3. Check `buildDir` output for correct directory structure reflecting `jcrPath`

### Questions:
- Does this add new dependencies (node, maven, ant, etc) that must be installed?
  - No
- Does this change the commands required to run this project?
  - No
- Are any environmental dependencies or operational support steps (sql commands, config changes, etc) required?
  - No
- Are there any relevant issues besides this one?
  - #40 
