### PR TITLE
fix: jcrPath option not working fixes #40

### DIFF
--- a/aem-packager.js
+++ b/aem-packager.js
@@ -16,6 +16,7 @@ const {
 
 // Define default fallbacks for all unset configs
 const defaults = require('./src/defaults.json')
+defaults.options.jcrPath = undefined // Set here so it exists when we loop later. Cannot be declared undefined in JSON
 
 // Merge configurations from various sources
 var configs = {}
@@ -80,7 +81,8 @@ const getDefines = function (configs) {
   // Apply configurations from paths
   const pathOptions = {
     srcDir: resolvePath(configs.options.srcDir),
-    buildDir: resolvePath(configs.options.buildDir)
+    buildDir: resolvePath(configs.options.buildDir),
+    jcrPath: configs.options.jcrPath // Doesn't use resolvePath() because this is not a filesystem path
   }
 
   _.defaults(


### PR DESCRIPTION
Fixes #40

## Proposed Changes

- Set default jcrPath to `undefined` instead of leaving it unset

## Background context

`jcrPath` option is not working currently, it always writes output to the default path when using package.json to define settings. This happens because we loop through a list of known variables, searching for their equivalents in process.env. Since the default `jcrPath` wasn't defined in the initial defaults object, it could never be found in package.json either. Setting it to `undefined` ensures it exists on the list of properties that are searched in package.json

### How should this be manually tested?

* Define a custom `options.jcrPath`
* Run packaging script
* Check verbose build output for used output directory
* Check `buildDir` output for correct directory structure reflecting `jcrPath`
* Remove configuration `options.jcrPath`
* Run packaging script
* Check `buildDir` output for directory structure matching project's package.json data

### Questions:
- Does this add new dependencies (node, maven, ant, etc) that must be installed?
  - no
- Does this change the commands required to run this project?
  - no
- Are any environmental dependencies or operational support steps (sql commands, config changes, etc) required?
  - no
- Are there any relevant issues besides this one?
  - no
