### PR TITLE
feat: verify maven is available when installing

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "aem-packager": "./aem-packager.js"
   },
   "scripts": {
+    "preinstall": "mvn -v",
     "pretest": "npm run lint",
     "test": "nyc mocha",
     "lint": "run-p lint:*",


### PR DESCRIPTION
Checks to see if maven is present when installing aem-packager by running `mvn -v` on preinstall hook.

If maven is not present, then the `npm install` will error out.