### PR TITLE
feat(deps): remove lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aem-packager",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4474,7 +4474,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   },
   "dependencies": {
     "command-line-args": "^5.1.1",
-    "lodash": "^4.17.11",
     "maven": "^4.4.1",
     "read-config-file": "^5.0.0"
   },

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 /**
  * Renames properties on an object by prepending a prefix to them. Mutates the original object.
  * @param {Object} - Object to modify
@@ -7,8 +5,8 @@ const _ = require('lodash')
  * @returns {Object} - Updated object with renamed properties
  **/
 const prefixProperties = function (obj, prefix) {
-  _.forEach(obj, function (val, prop) {
-    obj[prefix + prop] = val
+  Object.keys(obj).forEach((prop) => {
+    obj[prefix + prop] = obj[prop]
     delete obj[prop]
   })
 
@@ -49,9 +47,9 @@ const getConfigsFromProcess = function (defaults) {
   var result = {}
 
   // Walk the defaults object and map the names back to process.env names so we can find them
-  _.forEach(defaults, (val, config) => {
+  Object.keys(defaults).forEach( (config) => {
     result[config] = {}
-    _.forEach(defaults[config], (val, property) => {
+    Object.keys(defaults[config]).forEach( (property) => {
       const searchSegments = [
         'npm',
         'package', // namespace of where package.json options are stored

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -47,9 +47,9 @@ const getConfigsFromProcess = function (defaults) {
   var result = {}
 
   // Walk the defaults object and map the names back to process.env names so we can find them
-  Object.keys(defaults).forEach( (config) => {
+  Object.keys(defaults).forEach((config) => {
     result[config] = {}
-    Object.keys(defaults[config]).forEach( (property) => {
+    Object.keys(defaults[config]).forEach((property) => {
       const searchSegments = [
         'npm',
         'package', // namespace of where package.json options are stored


### PR DESCRIPTION
Replace the `lodash` loops with ES5 `Object.keys()` so `lodash` can be dropped.

## Proposed Changes

- Rewrite loops
- Remove lodash dependency

## Background context

`lodash` is big. Eliminating it for the runtime reduces the download size for consuming projects. Reducing the dependency footprint also reduces the risk of upstream security issues.

### Where should the reviewer start / What requires special attention?

`helper.js`

### How should this be manually tested?

1. Run an packager process in an example project with `npm run package`
2. Check folder `target` for build output
3. Confirm the validity of the generated `.zip` package

### Questions:
- Does this add new dependencies (node, maven, ant, etc) that must be installed?
  - No, it removes a dependency
- Does this change the commands required to run this project?
  - No
- Are any environmental dependencies or operational support steps (sql commands, config changes, etc) required?
  - No
- Are there any relevant issues besides this one?
  - No
