### PR TITLE
docs(badges): replace greenkeeper with dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-[![Greenkeeper badge](https://badges.greenkeeper.io/amclin/aem-packager.svg)](https://greenkeeper.io/)
+[![Dependabot Status](https://badgen.net/dependabot/amclin/aem-packager/?icon=dependabot)](https://dependabot.com)
 [![Build Status](https://travis-ci.org/amclin/aem-packager.svg?branch=master)](https://travis-ci.org/amclin/aem-packager)
 [![npm version](https://badge.fury.io/js/aem-packager.svg)](https://badge.fury.io/js/aem-packager)
 [![Dependencies Status](https://david-dm.org/amclin/aem-packager/status.svg)](https://david-dm.org/amclin/aem-packager)


### PR DESCRIPTION
Greenkeeper is shutting down: https://greenkeeper.io/

Greenkeeper has been disabled for this repo and all activities migrated over to Dependabot.

This PR just updates the badge