### PR TITLE
ci(travis): specify supported Node versions for nvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
  - lts/*
- - current
+ - 14
+ - 12
 jobs:
   include:
     # Define the release stage that runs semantic-release


### PR DESCRIPTION
Pin the NPM versions used for testing. Since v14 is released,
v13 is no longer valid, and the tag 'current' no longer works in the
command  `nvm install current`