### PR TITLE
fix: maven failing to resolve Adobe vault plugin

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -22,8 +22,8 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>adobe-public-releases</id>
-			<name>Adobe Basel Public Repository</name>
-			<url>http://repo.adobe.com/nexus/content/groups/public</url>
+			<name>Adobe Public Repository</name>
+			<url>https://repo.adobe.com/nexus/content/groups/public</url>
 			<releases>
 				<enabled>true</enabled>
 				<updatePolicy>never</updatePolicy>


### PR DESCRIPTION
Adobe vault plugin was not resolving because URL to the repo was http
and now requires https

Should resolve errors in maven when trying to use this plugin

```
Error:  Unresolveable build extension: Plugin com.day.jcr.vault:content-package-maven-plugin:0.0.24 or one of its dependencies could not be resolved: Failed to read artifact descriptor for com.day.jcr.vault:content-package-maven-plugin:jar:0.0.24 @ 
```