### PR TITLE
docs: replace dependency status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 ![Run Tests](https://github.com/amclin/aem-packager/workflows/Run%20Tests/badge.svg)
 [![npm version](https://badge.fury.io/js/aem-packager.svg)](https://badge.fury.io/js/aem-packager)
-[![Dependencies Status](https://david-dm.org/amclin/aem-packager.svg)](https://david-dm.org/amclin/aem-packager)
-[![devDependencies Status](https://david-dm.org/amclin/aem-packager.svg?type=dev)](https://david-dm.org/amclin/aem-packager?type=dev)
+[![Dependencies Status](https://img.shields.io/librariesio/release/npm/aem-packager)]()
 [![codebeat badge](https://codebeat.co/badges/106d7699-204f-40da-ab0a-4f59ee5ec064)](https://codebeat.co/projects/github-com-amclin-aem-packager-master)
 
 # aem-packager


### PR DESCRIPTION
david-dm.org is unreliable
https://github.com/alanshaw/david/issues/171
