### PR TITLE
Feat/jackrabbit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ typings/
 
 # next.js build output
 .next
+
+# Files generated dynamically when this plugin is run
+target/
+src/pom.xml

--- a/.remarkignore
+++ b/.remarkignore
@@ -1,0 +1,2 @@
+# Exclude auto-generated files
+CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ The settings for running the packager are populated through the `options` object
     "options": {
         "srcDir": "dist",
         "buildDir": "target"
-        "jcrPath": "/apps/mygroup/myapp/clientlibs"
+        "jcrPath": "/apps/mygroup/myapp/clientlibs",
+        "packager": "jackrabbit",
+        "legacyCRXSupport": false
     },
     "defines": {...}
 }
@@ -167,6 +169,29 @@ The working directory that Maven will use for compiling the build package. Defau
 #### jcrPath (string)
 
 The path in the JCR (AEM's storage system) where the module will be installed. Since most npm projects will likely be generating JS, CSS, and HTML assets, the default here when left blank, this will use the [`groupId`](#groupId) and [`artifactId`](#artifactId) to complete generate the full pattern `/apps/<groupId>/<artifactId>/clientlibs`
+
+#### packager (string)
+
+Switches which plugin to use for building the content package. Defaults to `jackrabbit` when not provided:
+-   `jackrabbit`: Will use the more modern [jackrabbit plugin](#jackrabbit-plugin)
+-   `jcrvault`: Will use the legacy [jcr vault](#jcr-vault-plugin)
+
+These two plugins work slightly differently.
+
+##### Jackrabbit Plugin
+
+The `filevault-package-maven-plugin` from [Apache Jackrabbit](https://jackrabbit.apache.org/filevault-package-maven-plugin/) is faster during package installation because it doesn't need to copy files. However, it doesn't have full backwards compatibility and does not support CRX deployment. It will not work with AEM 6.3 or earlier. If using `jackrabbit` with AEM 6.3, make sure also turn on `legacyCRXSupport` so that the JCR Vault plugin can also be included.
+
+##### JCR Vault Plugin
+
+While Adobe [provides documentation](https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/developer-tools/maven-plugin.html) on using the JCR Vault plugin, it is no longer maintained. There were significant compatibility issues between AEM 6.1 and 6.3. In addition, there have been reports of various network setups blocking it due to some historical issues involving HTTP URLs for registries and SSL certis.
+
+Choose this option if youChoosing this option is consistent with how `aem-packager` worked previous to v4.0
+
+#### crxCompatibility
+
+Enables backwards compatibility for CRX when using Jackrabbit for `packager`. Set boolean `true` or `false`. Defaults to `false`. When enabled, it includes the JCR Vault `content-package-maven-plugin` so that built packages have the necessary goals needed for CRX deployment. Has no effect if `packager` is set to `jcrvault`.
+
 
 ### Defines
 

--- a/aem-packager.js
+++ b/aem-packager.js
@@ -16,6 +16,7 @@ const {
 
 // Define default fallbacks for all unset configs
 const defaults = require('./src/defaults.json')
+const { assemblePom, writePom } = require('./src/template.js')
 defaults.options.jcrPath = undefined // Set here so it exists when we loop later. Cannot be declared undefined in JSON
 
 // Merge configurations from various sources
@@ -103,7 +104,13 @@ const getDefines = function (configs) {
  * @param {Object} configs Fully processed configuration object
  */
 const runMvn = function (configs) {
-  const pomPath = path.resolve(__dirname, 'src/pom.xml')
+  writePom(
+    assemblePom({
+      ...configs.options
+    })
+  )
+
+  const pomPath = path.resolve(__dirname, 'src', 'pom.xml')
   const commands = getCommands(pomPath)
   let defines = getDefines(configs)
   // Prepare the variables for the pom.xml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "aem-packager",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aem-packager",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "command-line-args": "^5.1.1",
         "maven": "^5.0.0",
-        "read-config-file": "^6.0.0"
+        "read-config-file": "^6.0.0",
+        "xmlbuilder2": "^3.1.1"
       },
       "bin": {
         "aem-packager": "aem-packager.js"
@@ -1467,6 +1468,50 @@
         "@octokit/openapi-types": "^19.0.0"
       }
     },
+    "node_modules/@oozcitak/dom": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
+      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/infra": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
+      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "dependencies": {
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
+      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/util": {
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
+      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
       "dev": true,
@@ -2762,7 +2807,6 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -4782,7 +4826,6 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -6654,9 +6697,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -14129,7 +14172,6 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/standard": {
@@ -15529,6 +15571,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xmlbuilder2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
+      "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
+      "dependencies": {
+        "@oozcitak/dom": "1.15.10",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "js-yaml": "3.14.1"
+      },
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "nyc mocha",
     "lint": "run-p lint:*",
     "lint:md": "remark .",
-    "lint:js": "standard"
+    "lint:js": "standard --fix"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.0",
@@ -64,7 +64,8 @@
   "dependencies": {
     "command-line-args": "^5.1.1",
     "maven": "^5.0.0",
-    "read-config-file": "^6.0.0"
+    "read-config-file": "^6.0.0",
+    "xmlbuilder2": "^3.1.1"
   },
   "remarkConfig": {
     "plugins": [

--- a/src/defaults.json
+++ b/src/defaults.json
@@ -1,7 +1,9 @@
 {
   "options": {
     "srcDir": "dist",
-    "buildDir": "target"
+    "buildDir": "target",
+    "packager": "jackrabbit",
+    "legacyCRXSupport": false
   },
   "defines": {
     "name": "My Project",

--- a/src/template.js
+++ b/src/template.js
@@ -1,0 +1,55 @@
+const Console = console
+const { create } = require('xmlbuilder2')
+const path = require('path')
+const fs = require('fs')
+
+const templateList = [
+  'pom', 'jcrvault', 'jackrabbit', 'legacyCRXSupport'
+]
+
+const loadTemplate = (template) => {
+  const file = path.resolve(__dirname, 'templates', `${template}.xml`)
+  const xmlStr = fs.readFileSync(file, 'utf8')
+  const xmlDoc = create(xmlStr)
+  return xmlDoc
+}
+
+const assemblePom = ({ mode = 'jackrabbit', legacyCRXSupport = false }) => {
+  try {
+    Console.debug(`Asembling a pom.xml that will use ${mode}`)
+
+    // load the templates
+    const templates = Object.fromEntries(
+      templateList.map((el) => [el, loadTemplate(el)])
+    )
+
+    const doc = templates.pom.root()
+    // Insertion goes after the last plugin in project.build.plugins
+    const plugins = doc.find(el => el.node.nodeName === 'build')
+      .find(el => el.node.nodeName === 'plugins')
+
+    // Toggle package
+    plugins.import(templates[mode])
+
+    // Toggle compatibility mode
+    if (mode === 'jackrabbit' && legacyCRXSupport) {
+      plugins.import(templates.legacyCRXSupport)
+    }
+
+    return doc
+  } catch (err) {
+    Console.error('Failed to asemble pom.xml from templates.', err)
+    throw err
+  }
+}
+
+const writePom = (xmlDoc) => {
+  const xml = xmlDoc.end({ prettyPrint: true })
+  const pomPath = path.resolve(__dirname, 'pom.xml')
+  fs.writeFileSync(pomPath, xml, 'utf8')
+}
+
+module.exports = {
+  assemblePom,
+  writePom
+}

--- a/src/templates/jackrabbit.xml
+++ b/src/templates/jackrabbit.xml
@@ -1,0 +1,23 @@
+<plugin>
+    <groupId>org.apache.jackrabbit</groupId>
+    <artifactId>filevault-package-maven-plugin</artifactId>
+    <version>1.3.4</version>
+    <extensions>true</extensions>
+    <configuration>
+        <name>${project.name}</name>
+        <group>${project.groupId}</group>
+        <validatorsSettings>
+            <jackrabbit-filter>
+                <options>
+                    <severityForUndefinedFilterRootAncestors>warn</severityForUndefinedFilterRootAncestors>
+                </options>
+            </jackrabbit-filter>
+        </validatorsSettings>
+        <filters>
+            <filter>
+                <mode>replace</mode>
+                <root>${project.jcrPath}</root>
+            </filter>
+        </filters>
+    </configuration>
+</plugin>

--- a/src/templates/jcrvault.xml
+++ b/src/templates/jcrvault.xml
@@ -1,0 +1,17 @@
+<plugin>
+    <groupId>com.day.jcr.vault</groupId>
+    <artifactId>content-package-maven-plugin</artifactId>
+    <version>0.0.24</version>
+    <extensions>true</extensions>
+    <configuration>
+        <name>${project.name}</name>
+        <group>${project.groupId}</group>
+        <failOnError>true</failOnError>
+        <filters>
+            <filter>
+                <mode>replace</mode>
+                <root>${project.jcrPath}</root>
+            </filter>
+        </filters>
+    </configuration>
+</plugin>

--- a/src/templates/legacyCRXSupport.xml
+++ b/src/templates/legacyCRXSupport.xml
@@ -1,0 +1,6 @@
+<plugin>
+    <!-- this plugin is only needed for crx package manager deployment -->
+    <groupId>com.day.jcr.vault</groupId>
+    <artifactId>content-package-maven-plugin</artifactId>
+    <version>1.0.4</version>
+</plugin>

--- a/src/templates/pom.xml
+++ b/src/templates/pom.xml
@@ -65,23 +65,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>com.day.jcr.vault</groupId>
-				<artifactId>content-package-maven-plugin</artifactId>
-				<version>0.0.24</version>
-				<extensions>true</extensions>
-				<configuration>
-					<name>${project.name}</name>
-					<group>${project.groupId}</group>
-					<failOnError>true</failOnError>
-					<filters>
-						<filter>
-							<mode>replace</mode>
-							<root>${project.jcrPath}</root>
-						</filter>
-					</filters>
-				</configuration>
-			</plugin>
+			<!-- plugin for package building inserts here -->
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Fixes #488
Closes #489

## Proposed Changes

Switches out the deprecated JCR Vault plugin
for content packages with the newer Jackrabbit.

Should speed up package installations, and reduce
the amount network or security errors around using
an old unmaintained plugin.

BREAKING CHANGE: no longer contains the necessary
maven plugins for CRX deployment functionalitty. To add legacy CRX support on top of Jackrabbit, set the new option `legacyCRXSupport` to true. To  restore the old `aem-packager` functionality entirely, set the new
option `packager` to `jcrvault`


### Questions:
- Does this add new dependencies (node, maven, ant, etc) that must be installed?
  - No
- Does this change the commands required to run this project?
  - Yes
- Are any environmental dependencies or operational support steps (sql commands, config changes, etc) required?
  - No
- Are there any relevant issues besides this one?
  - #488
  - #489 
